### PR TITLE
Update quickstart.mdx

### DIFF
--- a/pages/docs/getting-started/quickstart.mdx
+++ b/pages/docs/getting-started/quickstart.mdx
@@ -106,7 +106,7 @@ Once the server is generated, you can `cd <generated-server>` and run:
 ```
 
 ## Without using the CLI
-Assume the following OpenAPI document, save it to `oas-file.yaml`:
+Assume the following OpenAPI document, save it to `api/oas-file.yaml`:
 ```yaml
 openapi: 3.0.0
 info:


### PR DESCRIPTION
oas-file.yaml is expected in `api/` folder

### Initial checks

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linked an issue to this pull request? (Create one if it does not exist)
* [x] Have you used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?

### Bug <!-- Bug or Suggestion -->

#### Description
If you follow current docs as is, you will get `[oas-tools] ERROR: ValidationError: Specification file at /Users/tejuo/Desktop/last/api/oas-file.yaml not found`
Documentation currently has wrong file location expectation


#### Implementation details
Changed oas-file.yaml location in docs to match expectation
